### PR TITLE
Updates to fix issues in newer versions of Fedora

### DIFF
--- a/smartcard/demos/certificate_basics/intermediate.sh
+++ b/smartcard/demos/certificate_basics/intermediate.sh
@@ -44,8 +44,9 @@ basicConstraints       = CA:true
 keyUsage               = critical, digitalSignature, cRLSign, keyCertSign
 
 [ v3_intermediate_ca ]
-subjectKeyIdentifier   = hash
-authorityKeyIdentifier = keyid:always,issuer
+# https://github.com/openssl/openssl/issues/22966
+#subjectKeyIdentifier   = hash
+#authorityKeyIdentifier = keyid:always,issuer
 basicConstraints       = critical, CA:true, pathlen:0
 keyUsage               = critical, digitalSignature, cRLSign, keyCertSign
 

--- a/smartcard/demos/virtual_smart_cards/add_user_cert.sh
+++ b/smartcard/demos/virtual_smart_cards/add_user_cert.sh
@@ -10,6 +10,8 @@ PIN="123456"
 
 pushd $TESTDIR
 
+useradd -m $NAME
+
 if [ ! -f ${CADIR}/${NAME}.key ]; then
     echo "Could not find ${CADIR}/${NAME}.key"
     exit 1

--- a/smartcard/demos/virtual_smart_cards/demo.sh
+++ b/smartcard/demos/virtual_smart_cards/demo.sh
@@ -13,6 +13,7 @@ fi
 dnf -y install opensc openssl gnutls-utils softhsm nss-tools
 dnf -y copr enable jjelen/vsmartcard
 dnf -y install virt_cacard vpcd
+dnf -y install sssd-proxy
 
 mkdir -p $TESTDIR
 pushd $TESTDIR
@@ -131,7 +132,9 @@ pam_cert_auth = True
 
 [domain/shadowutils]
 debug_level = 9
-id_provider = files
+id_provider = proxy
+proxy_lib_name = files
+local_auth_policy = enable:smartcard
 
 [certmap/shadowutils/localuser1]
 debug_level = 9


### PR DESCRIPTION
The intermediaCA config file contained some attributes that were not supported.  In the past these were ignored due to a different bug.  With that bug resolved, the cnf file needs to be fixed.  More info here: https://github.com/openssl/openssl/issues/22966

Also adding a useradd to the virtual smart card add user cert script.

Not modifying the Ansible playbooks at this time.  These may be retired soon.

Adding sssd-proxy to dnf install in virtual smart card setup demo.sh